### PR TITLE
Update giving links for new platform

### DIFF
--- a/give.html
+++ b/give.html
@@ -63,9 +63,9 @@
                                             <section>
                                                 <p>We appreciate any and all donations from students, alumni, and fans of Scotch'n'Soda Theatre. Donations can be made through Carnegie Mellon Giving to the organization to help fund our productions and activities, to our alumni organization to support alumni engagement, or to our endowment.</p>
                                                 <p>
-                                                    <a href="https://give.cmu.edu/pmtx/giftselect?id=a41f4000000eIeR" target="_blank">Give to Scotch'n'Soda Theatre</a><br>
-                                                    <a href="https://give.cmu.edu/pmtx/giftselect?id=a41f4000000eIeV" target="_blank">Give to Scotch'n'Soda Alumni</a><br>
-                                                    <a href="https://give.cmu.edu/pmtx/giftselect?id=a412S000000xCJR" target="_blank">Give to Scotch'n'Soda Endowment</a><br>
+                                                    <a href="https://givenow.cmu.edu/campaigns/42524/donations/new?designation=scotchnsodatheatre" target="_blank">Give to Scotch'n'Soda Theatre</a><br>
+                                                    <a href="https://givenow.cmu.edu/campaigns/42524/donations/new?designation=scotchnsodainterestgroup" target="_blank">Give to Scotch'n'Soda Alumni</a><br>
+                                                    <a href="https://givenow.cmu.edu/campaigns/42524/donations/new?designation=scotchnsodaendowedfund" target="_blank">Give to Scotch'n'Soda Endowment</a><br>
                                                 </p>
                                             </section>
                                         </div>


### PR DESCRIPTION
Hello! I'm the current SnS alumni president (and original creator of this website). CMU switched over to a new giving platform today, and I wanted to make sure the links at [snstheatre.org/give](https://www.snstheatre.org/give) were up-to-date so alumni (and students) can easily find how to donate to any of our 3 designations.

This PR is just a simple update of those three links. These direct links go to the giving page and pre-populate the designation field based on which link you click.